### PR TITLE
#24 error container hides

### DIFF
--- a/Frontend/WirecardCheckoutSeamless/Bootstrap.php
+++ b/Frontend/WirecardCheckoutSeamless/Bootstrap.php
@@ -64,7 +64,7 @@ class Shopware_Plugins_Frontend_WirecardCheckoutSeamless_Bootstrap extends Shopw
      */
     public function getVersion()
     {
-        return '1.7.20';
+        return '1.7.21';
     }
 
     /**

--- a/Frontend/WirecardCheckoutSeamless/Views/responsive/frontend/_public/src/js/wirecard_seamless.js
+++ b/Frontend/WirecardCheckoutSeamless/Views/responsive/frontend/_public/src/js/wirecard_seamless.js
@@ -193,6 +193,7 @@ var wirecardPayment = {
                 $(contentArea).append('<p>' + message + '</p>');
                 break;
             case 'CLEAR':
+                container.css('display', "none");
                 $(contentArea).empty();
                 break;
             case 'NEW':


### PR DESCRIPTION
- when showError with parameter CLEAR gets called the error container
  gets emptied alongside as it gets hidden
